### PR TITLE
Support conversin to MP4 using ffmpeg

### DIFF
--- a/gui/qml/pages/FirstPage.qml
+++ b/gui/qml/pages/FirstPage.qml
@@ -54,6 +54,7 @@ Page {
         property real scale: 1.0
         property int quality: 100
         property bool smooth: false
+        property bool convert: true
     }
 
     SilicaFlickable {
@@ -64,6 +65,7 @@ Page {
         Column {
             id: column
             width: parent.width
+            spacing: Theme.paddingLarge
 
             PageHeader {
                 title: qsTr("Screenrecorder")
@@ -147,6 +149,16 @@ Page {
                 }
             }
 
+            TextSwitch {
+                id: convertSwitch
+                text: qsTr("Convert to MP4 (smaller files)")
+                checked: conf.convert
+                automaticCheck: false
+                onClicked: {
+                    conf.convert = !checked
+                }
+            }
+
             Button {
                 id: actionButton
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -160,6 +172,8 @@ Page {
                         return qsTr("Stop")
                     case 3:
                         return qsTr("Saving, please wait")
+                    case 4:
+                        return qsTr("Converting, please wait")
                     }
                 }
                 enabled: serviceState > 0 && serviceState < 3
@@ -175,8 +189,13 @@ Page {
                 }
             }
 
+            SectionHeader {
+                text: qsTr("File output:")
+                visible: filenameLabel.text
+            }
             Label {
                 id: filenameLabel
+                color: Theme.highlightColor
                 anchors.left: parent.left
                 anchors.right: parent.right
                 anchors.margins: Theme.horizontalPageMargin

--- a/gui/translations/screenrecorder-gui.ts
+++ b/gui/translations/screenrecorder-gui.ts
@@ -12,74 +12,89 @@
 <context>
     <name>FirstPage</name>
     <message>
-        <location filename="../qml/pages/FirstPage.qml" line="69"/>
+        <location filename="../qml/pages/FirstPage.qml" line="71"/>
         <source>Screenrecorder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/FirstPage.qml" line="79"/>
+        <location filename="../qml/pages/FirstPage.qml" line="81"/>
         <source>Frames per second</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/FirstPage.qml" line="80"/>
+        <location filename="../qml/pages/FirstPage.qml" line="82"/>
         <source>%1 fps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/FirstPage.qml" line="94"/>
+        <location filename="../qml/pages/FirstPage.qml" line="96"/>
         <source>Buffers to store frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/FirstPage.qml" line="95"/>
+        <location filename="../qml/pages/FirstPage.qml" line="97"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/FirstPage.qml" line="103"/>
+        <location filename="../qml/pages/FirstPage.qml" line="105"/>
         <source>Store all frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/FirstPage.qml" line="118"/>
+        <location filename="../qml/pages/FirstPage.qml" line="120"/>
         <source>JPEG frames quality</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/FirstPage.qml" line="119"/>
-        <location filename="../qml/pages/FirstPage.qml" line="133"/>
+        <location filename="../qml/pages/FirstPage.qml" line="121"/>
+        <location filename="../qml/pages/FirstPage.qml" line="135"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/FirstPage.qml" line="132"/>
+        <location filename="../qml/pages/FirstPage.qml" line="134"/>
         <source>Frames scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/FirstPage.qml" line="142"/>
+        <location filename="../qml/pages/FirstPage.qml" line="144"/>
         <source>Apply smooth transformation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/FirstPage.qml" line="156"/>
+        <location filename="../qml/pages/FirstPage.qml" line="154"/>
+        <source>Convert to MP4 (smaller files)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirstPage.qml" line="168"/>
         <source>Loading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/FirstPage.qml" line="158"/>
+        <location filename="../qml/pages/FirstPage.qml" line="170"/>
         <source>Record</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/FirstPage.qml" line="160"/>
+        <location filename="../qml/pages/FirstPage.qml" line="172"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/FirstPage.qml" line="162"/>
+        <location filename="../qml/pages/FirstPage.qml" line="174"/>
         <source>Saving, please wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirstPage.qml" line="176"/>
+        <source>Converting, please wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirstPage.qml" line="193"/>
+        <source>File output:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/recorder/src/dbusadaptor.cpp
+++ b/recorder/src/dbusadaptor.cpp
@@ -108,6 +108,17 @@ void DBusAdaptor::SetSmooth(bool smooth)
     qCDebug(logadaptor) << Q_FUNC_INFO << smooth;
 }
 
+bool DBusAdaptor::GetConvert() const
+{
+    return Recorder::instance()->m_options.convert;
+}
+
+void DBusAdaptor::SetConvert(bool convert)
+{
+    Recorder::instance()->m_options.convert = convert;
+    qCDebug(logadaptor) << Q_FUNC_INFO << convert;
+}
+
 bool DBusAdaptor::registerService()
 {
     QDBusConnection bus = QDBusConnection::systemBus();

--- a/recorder/src/dbusadaptor.h
+++ b/recorder/src/dbusadaptor.h
@@ -23,6 +23,7 @@ public:
     Q_PROPERTY(double Scale READ GetScale WRITE SetScale FINAL)
     Q_PROPERTY(int Quality READ GetQuality WRITE SetQuality FINAL)
     Q_PROPERTY(bool Smooth READ GetSmooth WRITE SetSmooth FINAL)
+    Q_PROPERTY(bool Convert READ GetConvert WRITE SetConvert FINAL)
 
 public slots:
     Q_NOREPLY void Quit();
@@ -51,6 +52,9 @@ public slots:
 
     bool GetSmooth() const;
     void SetSmooth(bool smooth);
+
+    bool GetConvert() const;
+    void SetConvert(bool convert);
 
 signals:
     void StateChanged(int state);

--- a/recorder/src/main.cpp
+++ b/recorder/src/main.cpp
@@ -76,6 +76,11 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
             app.translate("main", "Scale frames using SmoothTransformation."));
     parser.addOption(smoothOption);
 
+    QCommandLineOption convertOption(
+            {QStringLiteral("c"), QStringLiteral("convert")},
+            app.translate("main", "Convert final output to MP4."));
+    parser.addOption(convertOption);
+
     QCommandLineOption qualityOption(
             QStringLiteral("quality"),
             app.translate("main", "Frame JPEG compression quality."),
@@ -92,9 +97,15 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
             app.translate("main", "Write full frames. Including frames when idle. By default only changed frames are recorded."));
     parser.addOption(fullOption);
 
+    QCommandLineOption usedconfOption(
+            QStringLiteral("usedconf"),
+            app.translate("main", "Read the config from dconf when recording starts."));
+    parser.addOption(usedconfOption);
+
     parser.process(app);
 
     Recorder::Options options = Recorder::readOptions();
+    options.usedconf = parser.isSet(usedconfOption);
     if (parser.isSet(framerateOption)) {
         options.fps = parser.value(framerateOption).toInt();
         options.buffers = options.fps * 2;
@@ -109,6 +120,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
         options.quality = parser.value(qualityOption).toInt();
     }
     options.smooth = parser.isSet(fullOption);
+    options.convert = parser.isSet(convertOption);
     options.fullMode = parser.isSet(fullOption);
     options.daemonize = parser.isSet(daemonOption);
     if (options.daemonize) {

--- a/recorder/src/recorder.h
+++ b/recorder/src/recorder.h
@@ -38,6 +38,7 @@ class Recorder : public QObject
     Q_OBJECT
 public:
     struct Options {
+        bool usedconf;
         QString destination;
         int fps;
         int buffers;
@@ -45,6 +46,7 @@ public:
         double scale;
         int quality;
         bool smooth;
+        bool convert;
         bool daemonize;
     };
 
@@ -57,6 +59,7 @@ public:
         StatusReady,
         StatusRecording,
         StatusSaving,
+        StatusConverting,
     };
     Q_ENUM(Status)
     Status status() const;
@@ -85,6 +88,8 @@ private:
     static void frame(void *data, lipstick_recorder *recorder, wl_buffer *buffer, uint32_t time, int transform);
     static void failed(void *data, lipstick_recorder *recorder, int result, wl_buffer *buffer);
     static void cancel(void *data, lipstick_recorder *recorder, wl_buffer *buffer);
+    QString convert(const QString & filein);
+    static void logConfig(const Options &options);
 
     wl_display *m_display = nullptr;
     wl_registry *m_registry = nullptr;

--- a/recorder/systemd/screenrecorder.service
+++ b/recorder/systemd/screenrecorder.service
@@ -6,7 +6,7 @@ Conflicts=shutdown.target
 [Service]
 Type=dbus
 BusName=org.coderus.screenrecorder
-ExecStart=/usr/sbin/screenrecorder --daemon
+ExecStart=/usr/sbin/screenrecorder --daemon --usedconf
 User=nemo
 Group=privileged
 

--- a/rpm/screenrecorder.spec
+++ b/rpm/screenrecorder.spec
@@ -21,6 +21,8 @@ BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  systemd
 BuildRequires:  sailfish-svg2png
+Requires: ffmpeg
+Requires: ffmpeg-tools
 
 %description
 Lipstick recorder client


### PR DESCRIPTION
Adds an option to convert to MP4 for smaller file sizes. This introduces
a runtime dependencies on ffmpeg-tools.

A new option --usedconf has also been added to the background daemon,
which is activated by default. When set the daemon will read in the
configuration values from dconf every time a new recording is started,
ensuring that the action is consistent with the values set through the
UI.